### PR TITLE
temporarily update 0 time for 24 hour hack night

### DIFF
--- a/src/components/Clock/clock.tsx
+++ b/src/components/Clock/clock.tsx
@@ -6,9 +6,9 @@ export type ClockProps = {
     confettiCallback: () => void;
 };
 
-const midnightWarmupTime = "f~f~e|b";
-const midnight = "0~0~0|0";
-const midnightCooldownTime = "0~0~0|5";
+const midnightWarmupTime = "d~0~5|5";
+const midnight = "d~5~5|5";
+const midnightCooldownTime = "d~5~a|5";
 
 const midnightPartyStates = [
     "bottom-0",


### PR DESCRIPTION
updates to `d~5~5|5`, or 8pm. this should be reverted after today